### PR TITLE
Fix trusted commit checkout

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,6 @@
+# Vo3lk3rOS
+
+This repository contains the setup scripts for Vo3lk3rOS. The auto installer clones the repository and checks out a trusted commit to ensure a consistent installation.
+
+The current installer expects commit `b23bb62b674efb907f262a2b4965c8a1b8fe0089`.
+If you update the repository, adjust the commit hash in `system/auto_installer.sh` accordingly.

--- a/system/auto_installer.sh
+++ b/system/auto_installer.sh
@@ -2,6 +2,7 @@
 echo "[Vo3lk3rOS Auto-Installer] Repository wird geklont..."
 git clone https://github.com/Vo3lk3r/Vo3lk3rOS-.git /vo3lk3ros
 cd /vo3lk3ros
+git checkout b23bb62b674efb907f262a2b4965c8a1b8fe0089
 bash /vo3lk3ros/system/bootstrap_v1.sh
 bash /vo3lk3ros/system/install_gpts.sh
 bash /vo3lk3ros/moneymaker/start_moneymaker.sh


### PR DESCRIPTION
## Summary
- update `auto_installer.sh` to checkout the initial safe commit
- add `README.md` documenting the expected commit

## Testing
- `bash -n system/auto_installer.sh`

------
https://chatgpt.com/codex/tasks/task_e_68543a7b78f88327b44eaec0107cfbfb